### PR TITLE
Add domain and state/territory to i18next.

### DIFF
--- a/src/components/CustomFooter/CustomFooter.tsx
+++ b/src/components/CustomFooter/CustomFooter.tsx
@@ -16,7 +16,7 @@ import { Trans, useTranslation } from 'react-i18next'
 
 export const CustomFooter = () => {
   const { t } = useTranslation('components', { keyPrefix: 'footer' })
-
+  const { t: tPages } = useTranslation('pages', { keyPrefix: 'global' })
   return (
     <footer role="contentinfo">
       <GridContainer className="usa-footer__return-to-top">
@@ -30,13 +30,13 @@ export const CustomFooter = () => {
               <Icon.Home className="text-white" size={5} />
             </IdentifierLogo>
           </IdentifierLogos>
-          <IdentifierIdentity domain="{TO_DO_YOUR_DOMAIN_HERE}">
+          <IdentifierIdentity domain={tPages('domain')}>
             <Trans
               t={t}
               i18nKey="official"
               components={[
                 <Link key="official" href="/">
-                  {'{TO_DO_YOUR_STATE_OR_TERRITORY_HERE}'}
+                  {tPages('stateOrTerritory')}
                 </Link>,
               ]}
             />

--- a/src/i18n/en/components.ts
+++ b/src/i18n/en/components.ts
@@ -4,7 +4,7 @@ export default {
       flagImg: {
         alt: 'U.S. flag',
       },
-      text: 'This is an official website of {TODO_YOUR_STATE_OR_TERRITORY_HERE}',
+      text: 'This is an official website of $t(pages:global.stateOrTerritory)',
       actionText: "Here's how you know",
     },
     content: {
@@ -38,15 +38,14 @@ export default {
   footer: {
     returnTop: 'Return to top',
     identifierAria: 'Agency identifier',
-    official:
-      'An official website of <0>{TODO_YOUR_STATE_OR_TERRITORY_HERE}</0>',
+    official: 'An official website of <0>$t(pages:global.stateOrTerritory)</0>',
     links: 'Important links',
     link1: 'Link 1',
     link2: 'Link 2',
     link3: 'Link 3',
     home: 'Home',
     govAria: 'U.S. government information and services',
-    copyright: 'Copyright © 2023 {TODO_YOUR_STATE_OR_TERRITORY_HERE}',
+    copyright: 'Copyright © 2023 $t(pages:global.stateOrTerritory)',
   },
   header: {
     title: 'Unemployment Insurance Benefits',

--- a/src/i18n/en/pages.ts
+++ b/src/i18n/en/pages.ts
@@ -1,4 +1,8 @@
 export default {
+  global: {
+    domain: '{TO_DO_YOUR_DOMAIN_HERE}',
+    stateOrTerritory: '{TO_DO_YOUR_STATE_OR_TERRITORY_HERE}',
+  },
   claimStatus: {
     header: "We're reviewing your claim",
     success: 'Application submitted',
@@ -6,7 +10,7 @@ export default {
     review:
       "We are reviewing your application information to make sure you're eligible for benefits payments.",
     certify:
-      "You’ll need to certify each week to continue receiving benefits. Each time you certify, you should receive payment within a week.",
+      'You’ll need to certify each week to continue receiving benefits. Each time you certify, you should receive payment within a week.',
     potentialBenefits: {
       header: 'Potential benefits remaining',
       context: '(<0></0> paid so far)',
@@ -48,7 +52,7 @@ export default {
     },
     hasDriversLicenseOrStateId: {
       label:
-        "Do you have a driver's license or government issued ID for {TODO_YOUR_STATE_OR_TERRITORY_HERE}?",
+        "Do you have a driver's license or government issued ID for $t(global.stateOrTerritory)?",
       errors: {
         required:
           "You must answer whether you have a driver's license or state ID",


### PR DESCRIPTION
## Resolves #44 

Changes proposed in this pull request:

- Adds a `globals` section to the pages i18n file.
- Adds `domain` and `stateOrTerritory` to this object in place of having the "TO_DO" everywhere.
