### PR TITLE
Set up groups for renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,29 @@
     {
       "automerge": true,
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"]
+    },
+    {
+      "groupName": "Storybook",
+      "groupSlug": "storybook",
+      "matchPackagePrefixes": ["@storybook/"],
+      "matchPackageNames": ["eslint-plugin-storybook"]
+    },
+    {
+      "groupName": "Testing Library",
+      "groupSlug": "testing-library",
+      "matchPackagePrefixes": ["@testing-library/"]
+    },
+    {
+      "groupName": "React",
+      "groupSlug": "react",
+      "matchPackageNames": ["react", "react-dom"]
+    },
+    {
+      "groupName": "all non-major dependencies",
+      "groupSlug": "all-minor-patch",
+      "matchPackagePatterns": ["*"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
     }
   ],
   "separateMinorPatch": false


### PR DESCRIPTION
## Resolves #96 

Changes proposed in this pull request:

- Sets up a few groups for renovate to use when creating dependency update PRs
