### PR TITLE
Deploy storybook to github pages

### DIFF
--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -1,0 +1,58 @@
+name: Deploy Storybook to GitHub Pages
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows:
+      - "Test and Lint"
+    branches:
+      - main
+    types:
+      - completed
+
+concurrency:
+  group: storybook-deploy
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+
+      - name: Setup Node
+        uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8
+        with:
+          node-version-file: '.tool-versions'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install-ci
+
+      - name: Build storybook
+        run: yarn build-storybook
+
+      - name: Upload storybook
+        run: actions/upload-pages-artifact@64bcae551a7b18bcb9a09042ddf1960979799187
+        with:
+          path: ./storybook-static
+
+  deploy:
+    needs: build
+
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.pages_deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Deploy storybook
+        id: pages_deployment
+        uses: actions/deploy-pages@af48cf94a42f2c634308b1c9dc0151830b6f190a

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,11 +14,13 @@ jobs:
         node-version: [18.15.0]
 
     steps:
-      - uses: actions/checkout@f095bcc56b7c2baf48f3ac70d6d6782f4f553222
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8
         with:
           node-version: ${{ matrix.node }}
           cache: 'yarn'
-      - run: yarn install
-      - run: yarn test --coverage
+      - name: Install dependencies
+        run: yarn install-ci
+      - name: Run unit tests
+        run: yarn test --coverage

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ yarn-error.log
 
 # typescript
 *.tsbuildinfo
+
+# build artifacts
+storybook-static

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "yup": "^1.0.2"
   },
   "scripts": {
+    "install-ci": "yarn --frozen-lockfile",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "prepare": "husky install",


### PR DESCRIPTION
## Resolves #68 

Changes proposed in this pull request:

- Add github action for deploying storybook to gh pages
- Update the test action to use sha, and --frozen-lockfile for installing deps
