### PR TITLE
Update github action pinning for renovate

### DIFF
--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # renovate: tag=v3
 
       - name: Setup Node
-        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # renovate: tag=v3
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # renovate: tag=v2
         with:
           node-version-file: '.tool-versions'
           cache: 'yarn'

--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@f095bcc56b7c2baf48f3ac70d6d6782f4f553222
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # renovate: tag=v3
 
       - name: Setup Node
-        uses: actions/setup-node@a9893b0cfb0821c9c7b5fec28a6a2e6cdd5e20a4
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # renovate: tag=v3
         with:
           node-version-file: '.tool-versions'
           cache: 'yarn'
@@ -35,7 +35,7 @@ jobs:
         run: yarn build-storybook
 
       - name: Upload storybook
-        uses: actions/upload-pages-artifact@64bcae551a7b18bcb9a09042ddf1960979799187
+        uses: actions/upload-pages-artifact@64bcae551a7b18bcb9a09042ddf1960979799187 # renovate: tag=v1
         with:
           path: ./storybook-static
 
@@ -55,4 +55,4 @@ jobs:
     steps:
       - name: Deploy storybook
         id: pages_deployment
-        uses: actions/deploy-pages@af48cf94a42f2c634308b1c9dc0151830b6f190a
+        uses: actions/deploy-pages@af48cf94a42f2c634308b1c9dc0151830b6f190a # renovate: tag=v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # renovate: tag=v3
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # renovate: tag=v3
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # renovate: tag=v2
         with:
           node-version: ${{ matrix.node }}
           cache: 'yarn'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,9 @@ jobs:
         node-version: [18.15.0]
 
     steps:
-      - uses: actions/checkout@f095bcc56b7c2baf48f3ac70d6d6782f4f553222
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # renovate: tag=v3
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@a9893b0cfb0821c9c7b5fec28a6a2e6cdd5e20a4
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # renovate: tag=v3
         with:
           node-version: ${{ matrix.node }}
           cache: 'yarn'

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"],
+  "extends": [
+    "config:base",
+    "helpers:pinGitHubActionDigests"
+  ],
   "labels": ["dependencies"],
   "packageRules": [
     {


### PR DESCRIPTION
Resolves #102 

Changes proposed in this pull request:

- Updates our GitHub Actions version pinning to include a renovate tag so that renovate will update the digest based on the version tag rather than updating to the latest commit on main
- Adds `"helpers:pinGitHubActionDigests"` to the renovate config so that renovate will automatically pin action digests
